### PR TITLE
Fix gradient descent example for Python 3

### DIFF
--- a/code-python3/gradient_descent.py
+++ b/code-python3/gradient_descent.py
@@ -23,8 +23,8 @@ def plot_estimated_derivative():
     # plot to show they're basically the same
     import matplotlib.pyplot as plt
     x = range(-10,10)
-    plt.plot(x, map(derivative, x), 'rx')           # red  x
-    plt.plot(x, map(derivative_estimate, x), 'b+')  # blue +
+    plt.plot(x, [derivative(x_i) for x_i in x], 'rx')           # red  x
+    plt.plot(x, [derivative_estimate(x_i) for x_i in x], 'b+')  # blue +
     plt.show()                                      # purple *, hopefully
 
 def partial_difference_quotient(f, v, i, h):


### PR DESCRIPTION
The example producing Figure 8-3 in the book doesn't work in Python 3, apparently because the iterator returned by `map()` doesn't work with pyplot, so using a list comprehension here instead.
