### PR TITLE
Bug in `most_common_interests_with(user)` method definition corrected

### DIFF
--- a/code/introduction.py
+++ b/code/introduction.py
@@ -117,11 +117,11 @@ interests_by_user_id = defaultdict(list)
 for user_id, interest in interests:
     interests_by_user_id[user_id].append(interest)
 
-def most_common_interests_with(user_id):
+def most_common_interests_with(user):
     return Counter(interested_user_id
-        for interest in interests_by_user_id["user_id"]
+        for interest in interests_by_user_id[user["id"]]
         for interested_user_id in user_ids_by_interest[interest]
-        if interested_user_id != user_id)
+        if interested_user_id != user["id"])
 
 ###########################
 #                         #


### PR DESCRIPTION
Corrected `most_common_interests_with(user)` method definition is exactly the same as in the book (page8).
The same result as the proposed correction would give a method which takes `user_id = user["id"]`argument instead of a dict type `user` argument. However, in that case the code that would be iterating through all the users to display the results would be less clean:

- For `user` argument:
```python
for user in users:
    print most_common_interests_with(user)
```

- For `user_id` argument:
```python
for user_id in range(len(users)):
    print most_common_interests_with(user_id)
```