### PR TITLE
`def quantile (x, p)` correction in statistics.py

### DIFF
--- a/code/statistics.py
+++ b/code/statistics.py
@@ -47,7 +47,7 @@ def median(v):
         
 def quantile(x, p):
     """returns the pth-percentile value in x"""
-    p_index = int(p * len(x))
+    p_index = int(p * len(x)) - 1 # for sorted list x is indexed from 0 to len(x)-1
     return sorted(x)[p_index]
 
 def mode(x):


### PR DESCRIPTION
If the value `p = 1 (100%)` is chosen,  `sorted(x)[p_index]` is out of bounds because `p_index = p * len(x) = 1 * len(x) = len(x)` and the list `x` is indexed from `[0]` to `[len(x)-1]`. The proposed correction is to change line 50 of statistics.py from `p_index = int(p * len(x)) - 1` to `p_index = int(p * len(x)) - 1`.