### PR TITLE
Fixing 'Visualizing Data' link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and so on and so forth.
 
 1. Introduction
 2. A Crash Course in Python
-3. [Visualizing Data](https://github.com/joelgrus/data-science-from-scratch/blob/master/scratch/visualizing_data.py)
+3. [Visualizing Data](https://github.com/joelgrus/data-science-from-scratch/blob/master/scratch/visualization.py)
 4. [Linear Algebra](https://github.com/joelgrus/data-science-from-scratch/blob/master/scratch/linear_algebra.py)
 5. [Statistics](https://github.com/joelgrus/data-science-from-scratch/blob/master/scratch/statistics.py)
 6. [Probability](https://github.com/joelgrus/data-science-from-scratch/blob/master/scratch/probability.py)


### PR DESCRIPTION
Readme's 'Visualizing Data' is giving wrong link due to rename of visualization python file.