### PR TITLE
Make scratch.gradient_descent.partial_difference_quotient() publicly available

### DIFF
--- a/scratch/gradient_descent.py
+++ b/scratch/gradient_descent.py
@@ -16,6 +16,16 @@ def square(x: float) -> float:
 
 def derivative(x: float) -> float:
     return 2 * x
+    
+def partial_difference_quotient(f: Callable[[Vector], float],
+                                v: Vector,
+                                i: int,
+                                h: float) -> float:
+    """Returns the i-th partial difference quotient of f at v"""
+    w = [v_j + (h if j == i else 0)    # add h to just the ith element of v
+         for j, v_j in enumerate(v)]
+
+    return (f(w) - f(v)) / h
 
 def estimate_gradient(f: Callable[[Vector], float],
                       v: Vector,
@@ -77,18 +87,7 @@ def main():
     # plt.show()
     
     
-    plt.close()
-    
-    def partial_difference_quotient(f: Callable[[Vector], float],
-                                    v: Vector,
-                                    i: int,
-                                    h: float) -> float:
-        """Returns the i-th partial difference quotient of f at v"""
-        w = [v_j + (h if j == i else 0)    # add h to just the ith element of v
-             for j, v_j in enumerate(v)]
-    
-        return (f(w) - f(v)) / h
-    
+    plt.close()    
     
     # "Using the Gradient" example
     


### PR DESCRIPTION
At the moment, [`partial_difference_quotient()` is a private function in the `main()` function of _gradient_descent.py_](https://github.com/joelgrus/data-science-from-scratch/blob/master/scratch/gradient_descent.py#L82-L90). Since `partial_difference_quotient()` is used by [`estimate_gradient()`](https://github.com/joelgrus/data-science-from-scratch/blob/master/scratch/gradient_descent.py#L23) this means that import and usage of `estimate_gradient()` as in `from industrial_data_science.gradient_descent_from_scratch import estimate_gradient` is not possible as is. We moved the private function out of `main()` and thus make `estimate_gradient()` importable and applicable.