### PR TITLE
Updated to be compatible with current version of Twython

### DIFF
--- a/scratch/getting_data.py
+++ b/scratch/getting_data.py
@@ -317,8 +317,8 @@ def main():
             if len(tweets) >= 100:
                 self.disconnect()
     
-        def on_error(self, status_code, data):
-            print(status_code, data)
+        def on_error(self, status_code, data, headers=None):
+            print(status_code, data, headers)
             self.disconnect()
     
     stream = MyStreamer(CONSUMER_KEY, CONSUMER_SECRET,


### PR DESCRIPTION
Added headers=None argument to on_error method of MyStreamer. Without this, one gets the error `TypeError: on_error() takes 3 positional arguments but 4 were given` whenever on_error is called